### PR TITLE
Added signup, and validate enpoint POC

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1230,6 +1230,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,9 +11,11 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "body-parser": "^1.19.0",
         "express": "^4.17.1",
         "nodemon": "^2.0.13",
         "qrcodejs": "^1.0.0",
-        "totp-generator": "0.0.9"
+        "totp-generator": "0.0.9",
+        "uuid": "^8.3.2"
     }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,9 +1,43 @@
-const express = require("express");
+const express = require('express');
 const app = express();
 const port = process.env.PORT || 5000;
+const bodyParser = require('body-parser');
+const totp = require("totp-generator");
+const { v4: uuid } = require('uuid');
 
 app.listen(port, () => console.log(`Listening on port ${port}`));
+
+app.use(bodyParser.json());
+
+app.get('/', (req, res) => {
+    res.send('Hello World!');
+});
+
+app.get('/signup', (req, res) => {
+    const userId = generateUserId();
+    const sharedSecret = userId.split("-")[4];
+    res.send(JSON.stringify({userId, sharedSecret}));
+});
+
+app.get('/validate', (req, res) => {
+    const userId = req.body.userId;
+    const token = req.body.token;
+    res.send(verify(userId, token));
+});
 
 app.get("/ping", (req, res) => {
     res.send({ msg: "Backend is connected" });
 });
+
+function verify(userId, userTotp) {
+    const totpChallenge = totp(userId.split("-")[4], {
+        digits: 8,
+        period: 60,
+    });
+
+    return totpChallenge === userTotp;
+}
+
+function generateUserId() {
+    return uuid();
+}


### PR DESCRIPTION
Closes #2 and #4 

Two pieces left

- [ ] Storage of Unique IDs
- [ ] Validation of already existing Unique ID so hitting the `signup` endpoint a second time does not issue new creds.